### PR TITLE
Set WORKDIR to ZAMMAD_DIR

### DIFF
--- a/containers/zammad/Dockerfile
+++ b/containers/zammad/Dockerfile
@@ -30,3 +30,5 @@ RUN chmod +x /tmp/install-zammad.sh;/bin/bash -l -c /tmp/install-zammad.sh
 RUN apt-get remove --purge -y build-essential bzip2 git-core libffi-dev libgdbm3 libssl-dev procps zlib1g-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR $ZAMMAD_DIR


### PR DESCRIPTION
To easy run rails command insight the zammad folder the docker WORKDIR is set to the zammad folder
All exec commands now run directly in /home/zammad

Fixes: #29