### PR TITLE
Move mapping of port 80 to docker-compose.override.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3.3'
+services:
+
+  zammad-nginx:
+    ports:
+      - "80:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
     links:
       - zammad-railsserver
       - zammad-websocket
-    ports:
-      - "80:80"
     restart: always
     volumes:
       - data-zammad:/home/zammad


### PR DESCRIPTION
Moving the port mapping to override file makes it possible to easy use an reverse proxy for production.
This is necessary because it is not possible to remove a property with an override file.
See https://docs.docker.com/compose/extends/#understanding-multiple-compose-files

Resolves: #51