### PR TITLE
Expose port 80 of zammad-nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     restart: always
     volumes:
       - zammad-data:/opt/zammad
+    expose:
+      - "80"
 
   zammad-postgresql:
     image: ${IMAGE_REPO}:zammad-postgresql${VERSION}


### PR DESCRIPTION
After changing from nginx image to zammad + nginx it is necessary to expose port 80 of zammad-nginx service

Fixes: #61