### PR TITLE
Allow setting Elasticsearch connection URL protocol

### DIFF
--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 : "${AUTOWIZARD_JSON:=''}"
 : "${ELASTICSEARCH_HOST:=zammad-elasticsearch}"
 : "${ELASTICSEARCH_PORT:=9200}"
+: "${ELASTICSEARCH_SCHEMA:=http}"
 : "${MEMCACHED_HOST:=zammad-memcached}"
 : "${MEMCACHED_PORT:=11211}"
 : "${POSTGRESQL_HOST:=zammad-postgresql}"
@@ -56,7 +57,7 @@ if [ "$1" = 'zammad-init' ]; then
 
   # check if database is populated
   if [ "${DB_MIGRATE}" == "0" ]; then
-      bundle exec rails r "Setting.set('es_url', 'http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')" &> /dev/null
+      bundle exec rails r "Setting.set('es_url', '${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')" &> /dev/null
       DB_SETTINGS="$?"
   fi
   set -e
@@ -79,7 +80,7 @@ if [ "$1" = 'zammad-init' ]; then
 
   # es config
   echo "changing settings..."
-  bundle exec rails r "Setting.set('es_url', 'http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')"
+  bundle exec rails r "Setting.set('es_url', '${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')"
 
   if [ -n "${ELASTICSEARCH_USER}" ] && [ -n "${ELASTICSEARCH_PASS}" ]; then
     bundle exec rails r "Setting.set('es_user', \"${ELASTICSEARCH_USER}\")"
@@ -91,7 +92,7 @@ if [ "$1" = 'zammad-init' ]; then
     sleep 5
   done
 
-  if ! curl -s ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
+  if ! curl -s -k ${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
     echo "rebuilding es searchindex..."
     bundle exec rake searchindex:rebuild
   fi

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -6,6 +6,7 @@ set -e
 : "${ELASTICSEARCH_HOST:=zammad-elasticsearch}"
 : "${ELASTICSEARCH_PORT:=9200}"
 : "${ELASTICSEARCH_SCHEMA:=http}"
+: "${ELASTICSEARCH_SSL_VERIFY:=true}"
 : "${MEMCACHED_HOST:=zammad-memcached}"
 : "${MEMCACHED_PORT:=11211}"
 : "${POSTGRESQL_HOST:=zammad-postgresql}"

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -92,7 +92,12 @@ if [ "$1" = 'zammad-init' ]; then
     sleep 5
   done
 
-  if ! curl -s -k ${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
+  if [ "${ELASTICSEARCH_SSL_VERIFY}" == "false" ]; then
+    SSL_SKIP_VERIFY="-k"
+  else
+    SSL_SKIP_VERIFY=""
+  fi
+  if ! curl -s ${SSL_SKIP_VERIFY} ${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
     echo "rebuilding es searchindex..."
     bundle exec rake searchindex:rebuild
   fi


### PR DESCRIPTION
This adds handling of the `ELASTICSEARCH_SCHEMA` environment variable to the `zammad` image's entrypoint. It defaults to http so it's completely backwards-compatible.
In case it's `https` one can disable certificate verification in the `curl` command by setting `ELASTICSEARCH_SSL_VERIFY` to `false`. I saw that Zammad core also doesn't deal with that yet (see https://github.com/zammad/zammad/blob/develop/lib/user_agent.rb#L298) and mounting custom CA certificates isn't really feasible.