### PR TITLE
Fix nulldb errors arising in Rails 5.2

### DIFF
--- a/containers/zammad/setup.sh
+++ b/containers/zammad/setup.sh
@@ -33,8 +33,10 @@ if [ "$1" = 'install' ]; then
   bundle install --without test development mysql
   contrib/packager.io/fetch_locales.rb
   sed -e 's#.*adapter: postgresql#  adapter: nulldb#g' -e 's#.*username:.*#  username: postgres#g' -e 's#.*password:.*#  password: \n  host: zammad-postgresql\n#g' < contrib/packager.io/database.yml.pkgr > config/database.yml
+  sed -i "/require 'rails\/all'/a require\ 'nulldb'" config/application.rb
   sed -i '/# Use a different logger for distributed setups./a \ \ config.logger = Logger.new(STDOUT)' config/environments/production.rb
   sed -i 's/.*scheduler_\(err\|out\).log.*//g' script/scheduler.rb
+  touch db/schema.rb
   bundle exec rake assets:precompile
   rm -r tmp/cache
   chown -R "${ZAMMAD_USER}":"${ZAMMAD_USER}" "${ZAMMAD_TMP_DIR}"


### PR DESCRIPTION
TBH I'm not sure why nulldb wasn't failing before the upgrade to Rails 5.2. Here's what I do know:

1. [Current Circle CI builds are failing](https://circleci.com/gh/zammad/zammad/1387) with the following error:

       NullDB not configured. Require a framework, ex 'nulldb/rails'

   This error can be reproduced on a local machine:

       $ curl -L https://github.com/zammad/zammad/archive/stable.tar.gz | tar xz
       $ cd zammad-stable
       $ bundle install
       $ sed -e 's#.*adapter: postgresql#  adapter: nulldb#g' -e 's#.*username:.*#  username: postgres#g' -e 's#.*password:.*#  password: \n  host: zammad-postgresql\n#g' < contrib/packager.io/database.yml.pkgr > config/database.yml
       $ RAILS_ENV=production bundle exec rake assets:precompile

2. This can be fixed by explicitly calling `require 'nulldb'` during the application initialization process. Rails doesn't load the whole library automatically, but it _does_ load the [AR connection adapter](https://github.com/nulldb/nulldb/blob/master/lib/active_record/connection_adapters/nulldb_adapter.rb) automatically, and that file seems to load everything but `nulldb/rails`.

So to fix this problem, this PR simply amends `containers/zammad/setup.sh` to edit `config/application.rb` to explicitly `require 'nulldb'`.

---

Once you fix this problem, there's another that crops up when attempting to precompile assets:

```
LoadError: cannot load such file -- /home/rlue/tmp/zammad-stable/db/schema.rb
```

NullDB [attempts to load the schema](https://github.com/nulldb/nulldb/blob/master/lib/active_record/connection_adapters/nulldb_adapter/core.rb#L148) because, as explained it its README,

> NullDB needs to know where you keep your schema file in order to reflect table metadata.

Since we don't actually need a valid DB schema to precompile assets, this PR simply creates an empty file at `db/schema.rb` so that precompilation can succeed.