### PR TITLE
fix: missing POSTGRESQL_PORT in construct of database.yaml

### DIFF
--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -44,7 +44,7 @@ if [ "$1" = 'zammad-init' ]; then
   cd "${ZAMMAD_DIR}"
 
   # configure database
-  sed -e "s#.*adapter:.*#  adapter: postgresql#g" -e "s#.*database:.*#  database: ${POSTGRESQL_DB}#g" -e "s#.*username:.*#  username: ${POSTGRESQL_USER}#g" -e "s#.*password:.*#  password: ${POSTGRESQL_PASS}\\n  host: ${POSTGRESQL_HOST}\\n#g" < contrib/packager.io/database.yml.pkgr > config/database.yml
+  sed -e "s#.*adapter:.*#  adapter: postgresql#g" -e "s#.*database:.*#  database: ${POSTGRESQL_DB}#g" -e "s#.*username:.*#  username: ${POSTGRESQL_USER}#g" -e "s#.*password:.*#  password: ${POSTGRESQL_PASS}\\n  host: ${POSTGRESQL_HOST}\\n  port: ${POSTGRESQL_PORT}#g" < contrib/packager.io/database.yml.pkgr > config/database.yml
 
   # configure memcache
   sed -i -e "s/.*config.cache_store.*file_store.*cache_file_store.*/    config.cache_store = :dalli_store, '${MEMCACHED_HOST}:${MEMCACHED_PORT}'\\n    config.session_store = :dalli_store, '${MEMCACHED_HOST}:${MEMCACHED_PORT}'/" config/application.rb


### PR DESCRIPTION
in the `docker-entrypoint.sh` it was missing the use of POSTGRESQL_PORT when constructing database.yaml.
