### PR TITLE
Allow starting without Elasticsearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Like this, you can add your `docker-compose.prod.yml` to a branch of your Git re
 
 * RANCHER_URL=http://RANCHER_HOST:8080 rancher-compose --env-file=.env up
 
+## Running without Elasticsearch
+
+Elasticsearch is an optional, but strongly recommended dependency for Zammad. More details can be found in the [documentation](https://docs.zammad.org/en/latest/prerequisites/software.html#elasticsearch-optional). There are however certain scenarios when running without Elasticsearch may be desired, e.g. for very small teams, for teams with limited budget or as a temporary solution for an unplanned Elasticsearch downtime or planned cluster upgrade.
+
+Elasticsearch is enabled by default in the example `docker-compose.yml` file. It is also by default required to run the "zammad-init" command. Disabling Elasticsearch is possible by setting a special environment variable: `ELASTICSEARCH_ENABLED=false` for the `zammad-init` container and removing all references to Elasticsearch everywhere else: the `zammad-elasticsearch` container, it's volume and links to it.
+
 ## Upgrading
 
 ### From =< 3.3.0-12

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -3,6 +3,7 @@
 set -e
 
 : "${AUTOWIZARD_JSON:=''}"
+: "${ELASTICSEARCH_ENABLED:=true}"
 : "${ELASTICSEARCH_HOST:=zammad-elasticsearch}"
 : "${ELASTICSEARCH_PORT:=9200}"
 : "${ELASTICSEARCH_SCHEMA:=http}"
@@ -74,32 +75,36 @@ if [ "$1" = 'zammad-init' ]; then
   else
     bundle exec rake db:migrate
   fi
- 
+
   # es config
   echo "changing settings..."
-  bundle exec rails r "Setting.set('es_url', '${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')"
-
-  bundle exec rails r "Setting.set('es_index', '${ELASTICSEARCH_NAMESPACE}')"
-
-  if [ -n "${ELASTICSEARCH_USER}" ] && [ -n "${ELASTICSEARCH_PASS}" ]; then
-    bundle exec rails r "Setting.set('es_user', \"${ELASTICSEARCH_USER}\")"
-    bundle exec rails r "Setting.set('es_password', \"${ELASTICSEARCH_PASS}\")"
-  fi
-
-  until (echo > /dev/tcp/${ELASTICSEARCH_HOST}/${ELASTICSEARCH_PORT}) &> /dev/null; do
-    echo "zammad railsserver waiting for elasticsearch server to be ready..."
-    sleep 5
-  done
-
-  if [ "${ELASTICSEARCH_SSL_VERIFY}" == "false" ]; then
-    SSL_SKIP_VERIFY="-k"
+  if [ "${ELASTICSEARCH_ENABLED}" == "false" ]; then
+    bundle exec rails r "Setting.set('es_url', '')"
   else
-    SSL_SKIP_VERIFY=""
-  fi
-  
-  if ! curl -s ${SSL_SKIP_VERIFY} ${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
-    echo "rebuilding es searchindex..."
-    bundle exec rake searchindex:rebuild
+    bundle exec rails r "Setting.set('es_url', '${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}')"
+
+    bundle exec rails r "Setting.set('es_index', '${ELASTICSEARCH_NAMESPACE}')"
+
+    if [ -n "${ELASTICSEARCH_USER}" ] && [ -n "${ELASTICSEARCH_PASS}" ]; then
+      bundle exec rails r "Setting.set('es_user', \"${ELASTICSEARCH_USER}\")"
+      bundle exec rails r "Setting.set('es_password', \"${ELASTICSEARCH_PASS}\")"
+    fi
+
+    until (echo > /dev/tcp/${ELASTICSEARCH_HOST}/${ELASTICSEARCH_PORT}) &> /dev/null; do
+      echo "zammad railsserver waiting for elasticsearch server to be ready..."
+      sleep 5
+    done
+
+    if [ "${ELASTICSEARCH_SSL_VERIFY}" == "false" ]; then
+      SSL_SKIP_VERIFY="-k"
+    else
+      SSL_SKIP_VERIFY=""
+    fi
+
+    if ! curl -s ${SSL_SKIP_VERIFY} ${ELASTICSEARCH_SCHEMA}://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/_cat/indices | grep -q zammad; then
+      echo "rebuilding es searchindex..."
+      bundle exec rake searchindex:rebuild
+    fi
   fi
 
   # chown everything to zammad user


### PR DESCRIPTION
Hi team,

I'm not sure if it's something that you would like to merge considering the discussion in #160, but I found that option really useful. At the moment our company uses a forked version of this Docker image, so I thought that I'd try upstreaming our changes.

Reasons to support running the image without Elasticsearch:
1. Elasticsearch is a soft (strongly recommended!) dependency for Zammad. But it's not a hard one, so there's no reason why the Docker image should change the requirements. It should have the same requirements as DEBs or RPMs.
2. Adding such option to the image is very simple, doesn't add much maintentance cost in the future and some people might find it useful.
3. Some people run a small installation of Zammad and it works perfectly OK without ES and the only drawback is that reports are not available.
4. It could be used as a fallback mode. Let's imagine an outage of ES cluster (which happens from time to time in real life). A sysadmin could then temporarily restart Zammad without ES, until the problem with ES is fixed. It could also be useful when upgrading ES cluster as well.

Related issues:
* #119
* #160

