### PR TITLE
Migrate to elasticsearch OSS

### DIFF
--- a/containers/zammad-elasticsearch/Dockerfile
+++ b/containers/zammad-elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.10.1
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.1
 ARG BUILD_DATE
 
 LABEL org.label-schema.build-date="$BUILD_DATE" \


### PR DESCRIPTION
Hi @monotek - the Zammad main repository and default package [will support `elasticsearch` and `elasticsearch-oss`](https://github.com/zammad/zammad/commit/5a65e5bfcf030b2fa9ef19b136dcb9656be5c992) from the upcoming Zammad version 4.0 on. Our CI environment is also using `elasticsearch-oss` for some days now. I checked the `zammad-docker` container and [it's also using `elasticsearch-oss` for 2 years now](https://github.com/zammad/zammad-docker/commit/0641b481ed6b775a15170ffd059928d67cb2419b) (which surprised me a little).

Anyhow, do you see any obstacles switching to `elasticsearch-oss` in the `zammad-elasticsearch` image for `docker-compose`?