### PR TITLE
Fixes #205 - Automatically remove IPv6 listen directive

### DIFF
--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -121,8 +121,7 @@ if [ "$1" = 'zammad-nginx' ]; then
   check_zammad_ready
 
   # configure nginx
-  sed -e "/\[..\]:80/d" \
-      -e "s#listen .*#listen ${NGINX_PORT};#g" \
+  sed -e "s#\(listen\)\(.*\)80#\1\2${NGINX_PORT}#g" \
       -e "s#proxy_set_header X-Forwarded-Proto .*;#proxy_set_header X-Forwarded-Proto ${NGINX_SERVER_SCHEME};#g" \
       -e "s#server .*:3000#server ${ZAMMAD_RAILSSERVER_HOST}:${ZAMMAD_RAILSSERVER_PORT}#g" \
       -e "s#server .*:6042#server ${ZAMMAD_WEBSOCKET_HOST}:${ZAMMAD_WEBSOCKET_PORT}#g" \

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -121,7 +121,8 @@ if [ "$1" = 'zammad-nginx' ]; then
   check_zammad_ready
 
   # configure nginx
-  sed -e "s#listen .*#listen ${NGINX_PORT};#g" \
+  sed -e "/\[..\]:80/d" \
+      -e "s#listen .*#listen ${NGINX_PORT};#g" \
       -e "s#proxy_set_header X-Forwarded-Proto .*;#proxy_set_header X-Forwarded-Proto ${NGINX_SERVER_SCHEME};#g" \
       -e "s#server .*:3000#server ${ZAMMAD_RAILSSERVER_HOST}:${ZAMMAD_RAILSSERVER_PORT}#g" \
       -e "s#server .*:6042#server ${ZAMMAD_WEBSOCKET_HOST}:${ZAMMAD_WEBSOCKET_PORT}#g" \


### PR DESCRIPTION
This pull request addresses issue #205 which was introduced due to issue #3371 of the main zammad repo.

It removes the IPv6 listen directive *before* replacing listen directives which currently causes duplicate listen directives and thus results in crashing nginx containers.