### PR TITLE
Maintenance: Provide performance tuning options for docker-compose

### DIFF
--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec rails server puma -b [::] -p "${ZAMMAD_RAILSSERVER_PORT}" -e "${RAILS_ENV}" "${PUMA_OPTS}"
+  exec bundle exec rails server puma -b [::] -p "${ZAMMAD_RAILSSERVER_PORT} ${PUMA_OPTS}" -e "${RAILS_ENV}"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -27,7 +27,7 @@ set -e
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
 : "${ZAMMAD_WEBSOCKET_HOST:=zammad-websocket}"
 : "${ZAMMAD_WEBSOCKET_PORT:=6042}"
-: "${ZAMMAD_WEB_CONCURRENCY:=1}"
+: "${ZAMMAD_WEB_CONCURRENCY:=0}"
 
 function check_zammad_ready {
   sleep 15

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -c "/opt/zammad/config.ru"
+  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -C "/opt/zammad/config.ru"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}"
+  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -c "/opt/zammad/config.ru"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -C "/opt/zammad/config.ru"
+  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -C "/opt/zammad/config/puma.rb"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" ${PUMA_OPTS} -e "${RAILS_ENV}"
+  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -140,6 +140,7 @@ fi
 if [ "$1" = 'zammad-railsserver' ]; then
   test -f /opt/zammad/tmp/pids/server.pid && rm /opt/zammad/tmp/pids/server.pid
 
+  PUMA_OPTS=''
   if (( ZAMMAD_WEB_CONCURRENCY > 1 )); then
     PUMA_OPTS=" -w $ZAMMAD_WEB_CONCURRENCY"
   fi

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -27,8 +27,7 @@ set -e
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
 : "${ZAMMAD_WEBSOCKET_HOST:=zammad-websocket}"
 : "${ZAMMAD_WEBSOCKET_PORT:=6042}"
-: "${ZAMMAD_WEB_CONCURRENCY:=0}"
-: "${ZAMMAD_SESSION_JOBS_CONCURRENT:=}"
+: "${ZAMMAD_WEB_CONCURRENCY:=1}"
 
 function check_zammad_ready {
   sleep 15
@@ -140,11 +139,6 @@ fi
 if [ "$1" = 'zammad-railsserver' ]; then
   test -f /opt/zammad/tmp/pids/server.pid && rm /opt/zammad/tmp/pids/server.pid
 
-  PUMA_OPTS=''
-  if (( ZAMMAD_WEB_CONCURRENCY > 1 )); then
-    PUMA_OPTS=" -w $ZAMMAD_WEB_CONCURRENCY"
-  fi
-
   check_zammad_ready
 
   cd "${ZAMMAD_DIR}"
@@ -152,7 +146,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" "${PUMA_OPTS}" -e "${RAILS_ENV}" -C "/opt/zammad/config/puma.rb"
+  exec bundle exec puma -b tcp://[::]:"${ZAMMAD_RAILSSERVER_PORT}" -w "${ZAMMAD_WEB_CONCURRENCY}" -e "${RAILS_ENV}"
 fi
 
 

--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  exec bundle exec rails server puma -b [::] -p "${ZAMMAD_RAILSSERVER_PORT} ${PUMA_OPTS}" -e "${RAILS_ENV}"
+  exec bundle exec puma -b [::]:"${ZAMMAD_RAILSSERVER_PORT}" ${PUMA_OPTS} -e "${RAILS_ENV}"
 fi
 
 


### PR DESCRIPTION
Currently performance tuning is not possible within Zammads docker-compose. 
This can lead to huge performance issues on big instances. 

(See https://docs.zammad.org/en/latest/appendix/configure-env-vars.html#performance-tuning for more regarding performance tuning)

I believe our compose stack should be able to handle such things as well.

Please don't get confused by `$ZAMMAD_SESSION_JOBS_CONCURRENT` - it's required as ENV only, Zammad will handle the rest automatically while `$WEB_CONCURRENCY` needs puma parameters.