### PR TITLE
Maintenance: Provide a safer way to force a rebuild of the Elasticsearch volume data on upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ This repo is meant to be the starting point for somebody who likes to use docker
 In environments with more then one web applications it is necessary to use a reverse proxy to route connections to port 80 and 443 to the right application.
 To run Zammad behind a revers proxy, we provide `docker-compose.proxy-example.yml` as a starting point.
 
-1. Copy `./.examples/proxy/docker-compose.proxy-example.yml` to your own configuration, e.g. `./docker-compose.prod.yml`  
+1. Copy `./.examples/proxy/docker-compose.proxy-example.yml` to your own configuration, e.g. `./docker-compose.prod.yml`
     `cp ./.examples/proxy/docker-compose.proxy-example.yml ./docker-compose.prod.yml`
 2. Modify the environment variable `VIRTUAL_HOST` and the name of the external network in `./docker-compose.prod.yml` to fit your environment.
-3. Run docker-composer commands with the default and your configuration, e.g. `docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d`  
+3. Run docker-composer commands with the default and your configuration, e.g. `docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d`
 
 See `.examples/proxy/docker-compose.yml` for an example proxy project.
 
@@ -50,14 +50,13 @@ Elasticsearch is enabled by default in the example `docker-compose.yml` file. It
 
 We've updated the Elasticsearch image from 5.6 to 7.6.
 As there is no direct upgrade path we have to delete all Elasticsearch indices and rebuild them.
-Do the following to empty the ES docker volume:
+This will depend on the name of your docker container and volume, which depends on the checkout directory (`zammad-docker-compose` by default):
 
 ```console
 docker-compose stop
-set -o pipefail DOCKER_VOLUME="$(docker volume inspect zammaddockercompose_elasticsearch-data | grep Mountpoint | sed -e 's#.*": "##g' -e 's#",##')/*"
-echo "${DOCKER_VOLUME}" #check this is a valid docker volume path! if not do not proceed or you might lose data!
-rm -r $(docker volume inspect zammaddockercompose_elasticsearch-data | grep Mountpoint | sed -e 's#.*": "##g' -e 's#",##')/*
-docker-compose start
+docker container rm zammad-docker-compose_zammad-elasticsearch_1
+docker volume rm zammad-docker-compose_elasticsearch-data
+docker-compose up --no-recreate
 ```
 
 To workaround the [changes in the PostgreSQL 9.6 container](https://github.com/docker-library/postgres/commit/f1bc8782e7e57cc403d0b32c0e24599535859f76) do the following:


### PR DESCRIPTION
As indicated in the diff and in #223, there is a potential for data loss in the current upgrade routine. Provide a more safe approach by removing the ES container and volume only via the docker CLI.