### PR TITLE
Added zpm addon scripts deployment

### DIFF
--- a/containers/zammad/docker-entrypoint.sh
+++ b/containers/zammad/docker-entrypoint.sh
@@ -81,6 +81,13 @@ if [ "$1" = 'zammad-init' ]; then
     bundle exec rake db:migrate
   fi
 
+  # ensure package DB and asset changes are applied
+  if [ -d "${ZAMMAD_DIR}/auto_install/" ]; then
+    echo "Performing package migrations and rebuilding assets..."
+    bundle exec rake zammad:package:migrate
+    bundle exec rake assets:precompile
+  fi
+
   # es config
   echo "changing settings..."
   if [ "${ELASTICSEARCH_ENABLED}" == "false" ]; then


### PR DESCRIPTION
* once a zpm package is installed through auto_install, it populates ${ZAMMAD_DIR}/db/addon/<package> with rb scripts
* this commit now triggers package migration, and rebuilds assets