### PR TITLE
Maintenance: Raise Elasticsearch version to 7.16.1 to mitgitate log4j

### DIFF
--- a/containers/zammad-elasticsearch/Dockerfile
+++ b/containers/zammad-elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.1
 ARG BUILD_DATE
 
 LABEL org.label-schema.build-date="$BUILD_DATE" \


### PR DESCRIPTION
Simple image version raise of upstream to 7.16.1.
Elastic claims this version being not affected by log4j.