### PR TITLE
Bump compose-Version

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,4 @@ POSTGRES_USER=zammad
 REDIS_URL=redis://zammad-redis:6379
 RESTART=always
 # don't forget to add the minus before the version
-VERSION=-5.0.3-1
+VERSION=-5.0.3-7

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.0.1" \
+      org.label-schema.schema-version="5.0.3" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"

--- a/containers/zammad-elasticsearch/Dockerfile
+++ b/containers/zammad-elasticsearch/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.0.1" \
+      org.label-schema.schema-version="5.0.3" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/containers/zammad-postgresql/Dockerfile
+++ b/containers/zammad-postgresql/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.0.1" \
+      org.label-schema.schema-version="5.0.3" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/containers/zammad/Dockerfile
+++ b/containers/zammad/Dockerfile
@@ -37,7 +37,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.0.1" \
+      org.label-schema.schema-version="5.0.3" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 ENV GIT_BRANCH stable


### PR DESCRIPTION
This bumbs the schema version to 5.0.3 and updates the env version to 5.0.3-7 which contains the relevant ES 7.16.1 update for log4j.