### PR TITLE
Use latest elasticsearch version 7.16.2

### DIFF
--- a/containers/zammad-elasticsearch/Dockerfile
+++ b/containers/zammad-elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.16.2
 ARG BUILD_DATE
 
 LABEL org.label-schema.build-date="$BUILD_DATE" \


### PR DESCRIPTION
Use Elasticsearch 7.16.2 as it includes the latest, all-patched log4j 2.17.0. Elasticsearch is already not vulnerable in version 7.16.1 (see [announcement](https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476)), but better safe than sorry I guess.