### PR TITLE
Raise .env version to 5.0.3-14 to include ES 7.16.2

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,4 @@ POSTGRES_USER=zammad
 REDIS_URL=redis://zammad-redis:6379
 RESTART=always
 # don't forget to add the minus before the version
-VERSION=-5.0.3-7
+VERSION=-5.0.3-14

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ twitter, chat and emails. It is distributed under the GNU AFFERO General Public
  License (AGPL). Do you receive many emails and want to answer them with a team of agents?
 You're going to love Zammad!
 
-## Use case for this repositorysitory
+## Use case for this repository
 
 This repository is meant to be the starting point for somebody who likes to use dockerized multi-container Zammad in production.
 
@@ -30,7 +30,7 @@ To run Zammad behind a revers proxy, we provide `docker-compose.proxy-example.ym
 
 See `.examples/proxy/docker-compose.yml` for an example proxy project.
 
-Like this, you can add your `docker-compose.prod.yml` to a branch of your Git repositorysitory and stay up to date by merging changes to your branch.
+Like this, you can add your `docker-compose.prod.yml` to a branch of your Git repository and stay up to date by merging changes to your branch.
 
 ## Using Rancher
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 Zammad is a web based open source helpdesk/ticket system with many features
 to manage customer communication via several channels like telephone, facebook,
-twitter, chat and e-mails. It is distributed under the GNU AFFERO General Public
- License (AGPL). Do you receive many e-mails and want to answer them with a team of agents?
+twitter, chat and emails. It is distributed under the GNU AFFERO General Public
+ License (AGPL). Do you receive many emails and want to answer them with a team of agents?
 You're going to love Zammad!
 
-## Use case for this repo
+## Use case for this repositorysitory
 
-This repo is meant to be the starting point for somebody who likes to use dockerized multi-container Zammad in production.
+This repository is meant to be the starting point for somebody who likes to use dockerized multi-container Zammad in production.
 
 ## Getting started with zammad-docker-compose
 
-<https://docs.zammad.org/en/latest/install-docker-compose.html>
+[Learn more on Zammads documentation](https://docs.zammad.org/en/latest/install/docker-compose.html)
 
 ## CI Status
 
@@ -30,7 +30,7 @@ To run Zammad behind a revers proxy, we provide `docker-compose.proxy-example.ym
 
 See `.examples/proxy/docker-compose.yml` for an example proxy project.
 
-Like this, you can add your `docker-compose.prod.yml` to a branch of your Git repository and stay up to date by merging changes to your branch.
+Like this, you can add your `docker-compose.prod.yml` to a branch of your Git repositorysitory and stay up to date by merging changes to your branch.
 
 ## Using Rancher
 


### PR DESCRIPTION
This raises the `.env` version to `5.0.3-14` which includes Elasticsearch version 7.16.2 to complete the security related raise by https://github.com/zammad/zammad-docker-compose/pull/265