### PR TITLE
Raise env VERSION to latest available 5.1 version

### DIFF
--- a/.env
+++ b/.env
@@ -5,4 +5,4 @@ POSTGRES_USER=zammad
 REDIS_URL=redis://zammad-redis:6379
 RESTART=always
 # don't forget to add the minus before the version
-VERSION=-5.0.3-14
+VERSION=-5.1.0-4


### PR DESCRIPTION
This PR raises the env's version from 5.0.3-x to the latest available 5.1 tag.