### PR TITLE
Switch to Node.js 16 from Nodesource as that will be a dependency of Zammad 5.2 soon.

### DIFF
--- a/containers/zammad/Dockerfile
+++ b/containers/zammad/Dockerfile
@@ -37,7 +37,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-    org.label-schema.schema-version="5.1.0" \
+      org.label-schema.schema-version="5.1.0" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 ENV GIT_BRANCH stable

--- a/containers/zammad/setup.sh
+++ b/containers/zammad/setup.sh
@@ -3,7 +3,7 @@ set -e
 
 # install dependencies
 if [ "$1" = 'builder' ]; then
-  PACKAGES="build-essential curl git libimlib2-dev libpq-dev nodejs shared-mime-info"
+  PACKAGES="build-essential curl git libimlib2-dev libpq-dev shared-mime-info"
 elif [ "$1" = 'runner' ]; then
   PACKAGES="curl libimlib2 libpq5 nginx rsync"
 fi
@@ -12,6 +12,22 @@ apt-get update
 apt-get upgrade -y
 # shellcheck disable=SC2086
 apt-get install -y --no-install-recommends ${PACKAGES}
+
+if [ "$1" = 'builder' ]; then
+  # Install Node.js 16 repository from Nodesource
+  apt-get --no-install-recommends -y install gnupg
+  KEYRING=/usr/share/keyrings/nodesource.gpg
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$KEYRING" >/dev/null
+  cat - > /etc/apt/sources.list.d/nodesource.list <<NODESOURCE_LIST
+deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x buster main
+NODESOURCE_LIST
+
+  apt-get update
+  apt-get --no-install-recommends -y install nodejs
+  npm -g install yarn
+fi
+
+# Clean-up
 rm -rf /var/lib/apt/lists/*
 
 # install zammad


### PR DESCRIPTION
This change does not hurt for the stable branch as well, and affects only the builder image, not the runner.