### PR TITLE
Maintenance: Consistly raise Dockerfile versions to 5.2

### DIFF
--- a/containers/zammad-elasticsearch/Dockerfile
+++ b/containers/zammad-elasticsearch/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.1.0" \
+      org.label-schema.schema-version="5.2.0" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/containers/zammad-postgresql/Dockerfile
+++ b/containers/zammad-postgresql/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-url="https://github.com/zammad/zammad" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vendor="Zammad" \
-      org.label-schema.schema-version="5.1.0" \
+      org.label-schema.schema-version="5.2.0" \
       org.label-schema.docker.cmd="sysctl -w vm.max_map_count=262144;docker-compose up"
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Currently only the Zammad container was raised, but Elasticsearch and PGSQL should be as well.