### PR TITLE
adjust readme and docker image path

### DIFF
--- a/.env
+++ b/.env
@@ -4,5 +4,4 @@ POSTGRES_PASS=zammad
 POSTGRES_USER=zammad
 REDIS_URL=redis://zammad-redis:6379
 RESTART=always
-# don't forget to add the minus before the version
-VERSION=-5.2.3-32
+VERSION=5.2.3-35

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - POSTGRESQL_USER=${POSTGRES_USER}
       - POSTGRESQL_PASS=${POSTGRES_PASS}
       - REDIS_URL=${REDIS_URL}
-    image: ${IMAGE_REPO}:zammad${VERSION}
+    image: ${IMAGE_REPO}:${VERSION}
     restart: on-failure
     volumes:
       - zammad-data:/opt/zammad
@@ -52,7 +52,7 @@ services:
       - "8080"
     depends_on:
       - zammad-railsserver
-    image: ${IMAGE_REPO}:zammad${VERSION}
+    image: ${IMAGE_REPO}:${VERSION}
     restart: ${RESTART}
     volumes:
       - zammad-data:/opt/zammad
@@ -75,7 +75,7 @@ services:
     environment:
       - MEMCACHE_SERVERS=${MEMCACHE_SERVERS}
       - REDIS_URL=${REDIS_URL}
-    image: ${IMAGE_REPO}:zammad${VERSION}
+    image: ${IMAGE_REPO}:${VERSION}
     restart: ${RESTART}
     volumes:
       - zammad-data:/opt/zammad
@@ -93,7 +93,7 @@ services:
     environment:
       - MEMCACHE_SERVERS=${MEMCACHE_SERVERS}
       - REDIS_URL=${REDIS_URL}
-    image: ${IMAGE_REPO}:zammad${VERSION}
+    image: ${IMAGE_REPO}:${VERSION}
     restart: ${RESTART}
     volumes:
       - zammad-data:/opt/zammad
@@ -107,7 +107,7 @@ services:
     environment:
       - MEMCACHE_SERVERS=${MEMCACHE_SERVERS}
       - REDIS_URL=${REDIS_URL}
-    image: ${IMAGE_REPO}:zammad${VERSION}
+    image: ${IMAGE_REPO}:${VERSION}
     restart: ${RESTART}
     volumes:
       - zammad-data:/opt/zammad


### PR DESCRIPTION
Signed-off-by: André Bauer <andre.bauer@staffbase.com>

* adjust readme to point to our github releases for update instructions
  * weve created major releases for all breaking changes which wer made during existence of this repo
* docker image path has been updated to remove the "zammad-" prefix in front of the version
  * version in the .env file does not use "-" in fron of the version anmyore
* release draft of next version will look like:
  * https://github.com/zammad/zammad-docker-compose/releases
  * not sure if we should raise to 7.0 though, as the container image path changes (but its transparent for docler-compuse up)
