### PR TITLE
Define database name

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ MEMCACHE_SERVERS=zammad-memcached:11211
 POSTGRES_VERSION=15.1-alpine
 POSTGRES_PASS=zammad
 POSTGRES_USER=zammad
+POSTGRES_DB=zammad_production
 REDIS_URL=redis://zammad-redis:6379
 RESTART=always
 VERSION=5.4.1-29

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - HOLD_DAYS=10
       - POSTGRESQL_USER=${POSTGRES_USER}
       - POSTGRESQL_PASSWORD=${POSTGRES_PASS}
+      - POSTGRESQL_DB=${POSTGRES_DB}
       - TZ=Europe/Berlin
     image: postgres:${POSTGRES_VERSION}
     restart: ${RESTART}
@@ -36,6 +37,7 @@ services:
       - MEMCACHE_SERVERS=${MEMCACHE_SERVERS}
       - POSTGRESQL_USER=${POSTGRES_USER}
       - POSTGRESQL_PASS=${POSTGRES_PASS}
+      - POSTGRESQL_DB=${POSTGRES_DB}
       - REDIS_URL=${REDIS_URL}
     image: ${IMAGE_REPO}:${VERSION}
     restart: on-failure
@@ -62,6 +64,7 @@ services:
     environment:
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASS}
+      - POSTGRES_DB=${POSTGRES_DB}
     image: postgres:${POSTGRES_VERSION}
     restart: ${RESTART}
     volumes:


### PR DESCRIPTION
Set the database name to the default of the Zammad image to avoid an unused database with the name of the POSTGRES_USER var.

See default database name:
https://github.com/zammad/zammad/blob/163377fc65585cff78f021b385faf8af2c964253/contrib/docker/docker-entrypoint.sh#L20

See PostgreSQL image documentation:
https://hub.docker.com/_/postgres

POSTGRES_DB
This optional environment variable can be used to define a different name for the default database that is created when the image is first started. If it is not specified, then the value of POSTGRES_USER will be used.