### PR TITLE
Fixes #359 - Backup is constantly running.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,12 @@ services:
     environment:
       - BACKUP_TIME=03:00
       - HOLD_DAYS=10
-      - POSTGRESQL_DB=${POSTGRES_DB}
-      - POSTGRESQL_USER=${POSTGRES_USER}
-      - POSTGRESQL_PASSWORD=${POSTGRES_PASS}
       - TZ=Europe/Berlin
+      - POSTGRESQL_DB=${POSTGRES_DB}
+      - POSTGRESQL_HOST=${POSTGRES_HOST}
+      - POSTGRESQL_USER=${POSTGRES_USER}
+      - POSTGRESQL_PASS=${POSTGRES_PASS}
+      - POSTGRESQL_PORT=${POSTGRES_PORT}
     image: postgres:${POSTGRES_VERSION}
     restart: ${RESTART}
     volumes:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -4,11 +4,15 @@ set -e
 
 : "${ZAMMAD_DIR:=/opt/zammad/var}"
 : "${BACKUP_DIR:=/var/tmp/zammad}"
+: "${BACKUP_TIME:=03:00}"
 : "${ZAMMAD_RAILSSERVER_HOST:=zammad-railsserver}"
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
+: "${POSTGRESQL_DB:=zammad_production}"
 : "${POSTGRESQL_HOST:=zammad-postgresql}"
 : "${POSTGRESQL_PORT:=5432}"
-: "${POSTGRESQL_DB:=zammad_production}"
+: "${POSTGRESQL_USER:=zammad}"
+: "${POSTGRESQL_PASS:=zammad}"
+
 
 function check_railsserver_available {
   until (echo > "/dev/tcp/$ZAMMAD_RAILSSERVER_HOST/$ZAMMAD_RAILSSERVER_PORT") &> /dev/null; do
@@ -20,7 +24,7 @@ function check_railsserver_available {
 function zammad_backup {
   TIMESTAMP="$(date +'%Y%m%d%H%M%S')"
 
-  echo "${TIMESTAMP} - backuping zammad..."
+  echo "${TIMESTAMP} - backing up zammad..."
 
   # delete old backups
   if [ -d "${BACKUP_DIR}" ] && [ -n "$(ls "${BACKUP_DIR}")" ]; then
@@ -33,7 +37,7 @@ function zammad_backup {
   fi
 
   #db backup
-  pg_dump --dbname=postgresql://"${POSTGRESQL_USER}:${POSTGRESQL_PASSWORD}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DB}" | gzip > "${BACKUP_DIR}"/"${TIMESTAMP}"_zammad_db.psql.gz
+  pg_dump --dbname=postgresql://"${POSTGRESQL_USER}:${POSTGRESQL_PASS}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DB}" | gzip > "${BACKUP_DIR}"/"${TIMESTAMP}"_zammad_db.psql.gz
 
   echo "backup finished :)"
 }
@@ -45,7 +49,7 @@ if [ "$1" = 'zammad-backup' ]; then
   while true; do
     NOW_TIMESTAMP=$(date +%s)
     TOMORROW_DATE=$(date -d@"$((NOW_TIMESTAMP + 24*60*60))" +%Y-%m-%d)
-    
+
     zammad_backup
 
     NEXT_TIMESTAMP=$(date -d "$TOMORROW_DATE $BACKUP_TIME" +%s)


### PR DESCRIPTION
- Fixes #359 by making sure the variable `BACKUP_TIME` is always set, even if not passed to the container.
- Makes sure all database related variables get passed to the backup container (e.g. host and port), and also pre-populated in the backup script if missing.
- Unify naming of the password parameter to `POSTGRESQL_PASS` like in the entrypoint.
- Small English grammar improvement.