### PR TITLE
Closes: #379 - Add mount point for /opt/zammad/storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ x-shared:
     image: ${IMAGE_REPO}:${VERSION}
     restart: ${RESTART}
     volumes:
+      - zammad-storage:/opt/zammad/storage
       - zammad-var:/opt/zammad/var
     depends_on:
       - zammad-memcached
@@ -57,6 +58,7 @@ services:
     restart: ${RESTART}
     volumes:
       - zammad-backup:/var/tmp/zammad
+      - zammad-storage:/opt/zammad/storage:ro
       - zammad-var:/opt/zammad/var:ro
       - ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
 
@@ -75,6 +77,7 @@ services:
     user: 0:0
     volumes:
       - zammad-config-nginx:/etc/nginx/sites-enabled
+      - zammad-storage:/opt/zammad/storage
       - zammad-var:/opt/zammad/var
 
   zammad-memcached:
@@ -91,6 +94,7 @@ services:
       - zammad-railsserver
     volumes:
       - zammad-config-nginx:/etc/nginx/sites-enabled:ro
+      - zammad-storage:/opt/zammad/storage:ro
       - zammad-var:/opt/zammad/var:ro
 
   zammad-postgresql:
@@ -131,6 +135,8 @@ volumes:
   zammad-backup:
     driver: local
   zammad-config-nginx:
+    driver: local
+  zammad-storage:
     driver: local
   zammad-var:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,7 @@ services:
       - zammad-railsserver
     volumes:
       - zammad-config-nginx:/etc/nginx/sites-enabled:ro
-      - zammad-storage:/opt/zammad/storage:ro
-      - zammad-var:/opt/zammad/var:ro
+      - zammad-var:/opt/zammad/var:ro # required for the zammad-ready check file
 
   zammad-postgresql:
     environment:


### PR DESCRIPTION
It will not hurt to have this mount point, even if it is not used by default. Instead, it will make maintenance easier.