### PR TITLE
Fixes #381 - Zammad-NGINX can not write config file due to read-only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,6 @@ services:
     restart: on-failure
     user: 0:0
     volumes:
-      - zammad-config-nginx:/etc/nginx/sites-enabled
       - zammad-storage:/opt/zammad/storage
       - zammad-var:/opt/zammad/var
 
@@ -93,7 +92,6 @@ services:
     depends_on:
       - zammad-railsserver
     volumes:
-      - zammad-config-nginx:/etc/nginx/sites-enabled:ro
       - zammad-var:/opt/zammad/var:ro # required for the zammad-ready check file
 
   zammad-postgresql:
@@ -132,8 +130,6 @@ volumes:
   redis-data:
     driver: local
   zammad-backup:
-    driver: local
-  zammad-config-nginx:
     driver: local
   zammad-storage:
     driver: local


### PR DESCRIPTION
It seems that the description in #381 is correct. The current handling of the volume `zammad-config-nginx` seems to be wrong:
- the nginx config does not get written by the  `zammad-init`, but by the `zammad-nginx` container, and thus cannot be handed over in a volume
- even if `/etc/nginx/sites-enabled/` is readonly, it contains a symlink `default` which points to a file that is still writable - which is why it did work on my system properly

For me the conclusion is that we just need to remove this volume again so that the modifications are local to the `zammad-nginx` container.