### PR TITLE
Switch to Zammad 6.2.

### DIFF
--- a/.env
+++ b/.env
@@ -11,4 +11,4 @@ POSTGRES_VERSION=15.3-alpine
 REDIS_URL=redis://zammad-redis:6379
 REDIS_VERSION=7.0.5-alpine
 RESTART=always
-VERSION=6.1.0-58
+VERSION=6.2


### PR DESCRIPTION
This also switches from commit-level Zammad image reference to a floating value that will update within the minor release automatically. That's the recommended behaviour which is also active for package installations. It can still be changed locally.