### PR TITLE
Maintenance: Remove obsolete version field from docker-compose.yml files

### DIFF
--- a/.examples/proxy/docker-compose.proxy-example.yml
+++ b/.examples/proxy/docker-compose.proxy-example.yml
@@ -1,6 +1,4 @@
 ---
-version: "2"
-
 services:
   zammad-nginx:
     environment:

--- a/.examples/proxy/docker-compose.yml
+++ b/.examples/proxy/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '2'
-
 services:
   frontend:
     image: jwilder/nginx-proxy:alpine

--- a/docker-compose.override-local.yml
+++ b/docker-compose.override-local.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 services:
 
   zammad-init:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,4 @@
 ---
-version: '3'
-
 services:
 
   zammad-nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: '3.8'
-
 x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment


### PR DESCRIPTION
The version field has become obsolete and causes warnings to be emitted by docker compose. There was also a mismatch in the versions fields (3.8 vs. 3) which causes issues with Portainer.

https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete