### PR TITLE
Revert version drop

### DIFF
--- a/.examples/proxy/docker-compose.proxy-example.yml
+++ b/.examples/proxy/docker-compose.proxy-example.yml
@@ -1,4 +1,6 @@
 ---
+version: "2"
+
 services:
   zammad-nginx:
     environment:

--- a/.examples/proxy/docker-compose.yml
+++ b/.examples/proxy/docker-compose.yml
@@ -1,4 +1,6 @@
 ---
+version: '2'
+
 services:
   frontend:
     image: jwilder/nginx-proxy:alpine

--- a/docker-compose.override-local.yml
+++ b/docker-compose.override-local.yml
@@ -1,4 +1,6 @@
 ---
+version: '3'
+
 services:
 
   zammad-init:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,6 @@
 ---
+version: '3'
+
 services:
 
   zammad-nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 ---
+version: '3.8'
+
 x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.8'
+version: '3'
 
 x-shared:
   zammad-service: &zammad-service


### PR DESCRIPTION
It turned out that dropping the version breaks older toolchains such as portainer completely. Revert the change and also unify the used version to avoid conflicts.