### PR TITLE
Maintenance: Unify docker compose versions to more recent 3.8

### DIFF
--- a/.examples/proxy/docker-compose.proxy-example.yml
+++ b/.examples/proxy/docker-compose.proxy-example.yml
@@ -1,5 +1,5 @@
 ---
-version: "2"
+version: "3.8"
 
 services:
   zammad-nginx:

--- a/.examples/proxy/docker-compose.yml
+++ b/.examples/proxy/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: '3.8'
 
 services:
   frontend:

--- a/docker-compose.override-local.yml
+++ b/docker-compose.override-local.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.8'
 
 services:
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.8'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: '3.8'
 
 x-shared:
   zammad-service: &zammad-service


### PR DESCRIPTION
☹️ I wanted to keep the changes minimal, but using `version: 3` everywhere does not work, because it does not include features we need in the main composer.yml (custom `x-*` attributes). So standardize all places to `3.8` instead, for older toolchains which still respect the version field.