### PR TITLE
Added entrypoint to portainer command list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ x-shared:
       - zammad-memcached
       - zammad-postgresql
       - zammad-redis
+    labels:
+      io.portainer.commands.bash-via-entrypoint: "/docker-entrypoint.sh /bin/bash"
 
 services:
 
@@ -97,8 +99,6 @@ services:
   zammad-railsserver:
     <<: *zammad-service
     command: ["zammad-railsserver"]
-    labels:
-      io.portainer.commands.bash-via-entrypoint: "/docker-entrypoint.sh /bin/bash"
 
   zammad-redis:
     image: redis:${REDIS_VERSION:-7.2.5-alpine}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
   zammad-railsserver:
     <<: *zammad-service
     command: ["zammad-railsserver"]
+    labels:
+      io.portainer.commands.bash-via-entrypoint: "/docker-entrypoint.sh /bin/bash"
 
   zammad-redis:
     image: redis:${REDIS_VERSION:-7.2.5-alpine}


### PR DESCRIPTION
When accessing the railsserver-container within portainer, you need to enter via /docker-entrypoint.sh for the rails console to work. This label makes sure to add that variant to the available options in the command selection.

Details available here:
https://github.com/portainer/portainer/pull/2159