### PR TITLE
Update to Zammad 6.4, and perform major dependency updates including postgres 17.

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,7 +1,7 @@
-# ELASTICSEARCH_VERSION=8.15.2
+# ELASTICSEARCH_VERSION=8.15.3
 # IMAGE_REPO=ghcr.io/zammad/zammad
 # MEMCACHE_SERVERS=zammad-memcached:11211
-# MEMCACHE_VERSION=1.6.31-alpine
+# MEMCACHE_VERSION=1.6.32-alpine
 # NGINX_PORT=8080
 # NGINX_EXPOSE_PORT=8080
 # POSTGRES_DB=zammad_production
@@ -9,13 +9,13 @@
 # POSTGRES_USER=zammad
 # POSTGRES_HOST=zammad-postgresql
 # POSTGRES_PORT=5432
-# POSTGRES_VERSION=15.8-alpine
+# POSTGRES_VERSION=17.0-alpine
 # POSTGRESQL_OPTIONS=?pool=50
 # REDIS_URL=redis://zammad-redis:6379
 # REDIS_VERSION=7.4.1-alpine
 # RESTART=always
 # Use a fixed version. You are responsible to update this to newer patch level versions yourself.
-# VERSION=6.3.1-196
+# VERSION=6.4.0
 # You can also use floating versions that will give you automatic updates:
 # VERSION=6.2     # all patchlevel updates
 # VERSION=6       # including minor updates

--- a/.github/updatecli.yaml
+++ b/.github/updatecli.yaml
@@ -6,7 +6,10 @@ sources:
     spec:
       image: "zammad/zammad-docker-compose"
       architecture: "linux/amd64"
-      tagfilter: "6\\.3\\.1-\\d{3}"
+      tagfilter: "^6\\.4\\.0$"
+      # tagfilter: "^6\\.4\\.0-\\d{1}"
+      # tagfilter: "^6\\.4\\.0-\\d{2}"
+      # tagfilter: "^6\\.4\\.0-\\d{3}"
   elasticsearch:
     kind: dockerimage
     spec:
@@ -22,7 +25,7 @@ sources:
       architecture: "linux/amd64"
       versionfilter:
         kind: "semver"
-        pattern: "1.6.x"
+        pattern: "1.x.x"
   postgresql:
     kind: dockerimage
     spec:
@@ -30,7 +33,7 @@ sources:
       architecture: "linux/amd64"
       versionfilter:
         kind: "semver"
-        pattern: "15.x.x"
+        pattern: "17.x.x"
   redis:
     kind: dockerimage
     spec:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ x-shared:
       ZAMMAD_SESSION_JOBS:
       ZAMMAD_PROCESS_SCHEDULED:
       ZAMMAD_PROCESS_DELAYED_JOBS_WORKERS:
-    image: ${IMAGE_REPO:-ghcr.io/zammad/zammad}:${VERSION:-6.3.1-196}
+    image: ${IMAGE_REPO:-ghcr.io/zammad/zammad}:${VERSION:-6.4.0}
     restart: ${RESTART:-always}
     volumes:
       - zammad-storage:/opt/zammad/storage
@@ -56,7 +56,7 @@ services:
     user: 0:0
 
   zammad-elasticsearch:
-    image: bitnami/elasticsearch:${ELASTICSEARCH_VERSION:-8.15.2}
+    image: bitnami/elasticsearch:${ELASTICSEARCH_VERSION:-8.15.3}
     restart: ${RESTART:-always}
     volumes:
       - elasticsearch-data:/bitnami/elasticsearch/data
@@ -71,7 +71,7 @@ services:
 
   zammad-memcached:
     command: memcached -m 256M
-    image: memcached:${MEMCACHE_VERSION:-1.6.31-alpine}
+    image: memcached:${MEMCACHE_VERSION:-1.6.32-alpine}
     restart: ${RESTART:-always}
 
   zammad-nginx:
@@ -89,7 +89,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-zammad_production}
       POSTGRES_USER: ${POSTGRES_USER:-zammad}
       POSTGRES_PASSWORD: ${POSTGRES_PASS:-zammad}
-    image: postgres:${POSTGRES_VERSION:-15.8-alpine}
+    image: postgres:${POSTGRES_VERSION:-17.0-alpine}
     restart: ${RESTART:-always}
     volumes:
       - postgresql-data:/var/lib/postgresql/data


### PR DESCRIPTION
This includes a major update for the postgres dependency from 15 to 17, which requires manual action to upgrade the postgresql cluster data to the new version.