### PR TITLE
Include S3_URL as a supported environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-shared:
       POSTGRESQL_OPTIONS: ${POSTGRESQL_OPTIONS:-?pool=50}
       POSTGRESQL_DB_CREATE:
       REDIS_URL: ${REDIS_URL:-redis://zammad-redis:6379}
+      S3_URL:
       # Backup settings
       BACKUP_DIR: "${BACKUP_DIR:-/var/tmp/zammad}"
       BACKUP_TIME: "${BACKUP_TIME:-03:00}"


### PR DESCRIPTION
Currently docker users that regularly pull in the release `docker-compose.yml` file are unable to use S3 storage. This PR expands support for the primary docker-compose to include that environment variable.