### PR TITLE
Removed obsolete version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment


### PR DESCRIPTION
Removing the obsolete version in docker-compose.yml as its causing a warning when running the stack.
Deprecated as described in https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md