### PR TITLE
Add scenarios/disable-elasticsearch-service.yml to .env.dist

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -64,6 +64,12 @@
 # CLOUDFLARE_TUNNEL_TOKEN=mytoken
 
 #############################################
+# scenarios/disable-elasticsearch-service.yml
+#############################################
+
+ELASTICSEARCH_ENABLED=true
+
+#############################################
 # scenarios/add-external-network-to-nginx.yml
 #############################################
 


### PR DESCRIPTION
The environment variable is stated in the readme but missing in in the .env file.