### PR TITLE
Add support for restore mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     command: ["zammad-backup"]
     volumes:
       - zammad-backup:/var/tmp/zammad
-      - zammad-storage:/opt/zammad/storage:ro
+      - zammad-storage:/opt/zammad/storage
     user: 0:0
 
   zammad-elasticsearch:


### PR DESCRIPTION
Zammad 7.0 will feature restoring backups in docker. This happens inside the `zammad-backup` container, which therefore needs to mount the `zammad-storage` volume in `rw` mode rather than `ro` so that files can actually be restored.