### PR TITLE
Pass resource ENVs to zammad-elasticsearch container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,12 @@ services:
       ELASTICSEARCH_ENABLE_REST_TLS: 'false'
       # ELASTICSEARCH_USER is hardcoded to 'elastic' in the container.
       ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_PASS:-zammad}
+      # Resource settings
+      ELASTICSEARCH_HEAP_SIZE:
+      ELASTICSEARCH_MAX_ALLOWED_MEMORY_PERCENTAGE:
+      ELASTICSEARCH_MAX_ALLOWED_MEMORY:
+      ELASTICSEARCH_MAX_TIMEOUT:
+      ELASTICSEARCH_LOCK_ALL_MEMORY:
 
   zammad-init:
     <<: *zammad-service


### PR DESCRIPTION
https://hub.docker.com/r/bitnami/elasticsearch has a lot of variables. It probably does not make sense to pass all of them in our yml file (and keep maintaining the list), but this PR adds a selection that are relevant for resource control (memory and init timeout). We can add more in future, as neede.