### PR TITLE
Maintenance: Switch from bitnami/elasticsearch to library/elasticsearch

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -47,6 +47,7 @@
 # ELASTICSEARCH_PASS=zammad
 # ELASTICSEARCH_NAMESPACE=zammad
 # ELASTICSEARCH_REINDEX=true
+# ELASTICSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
 
 # Variables used by ngingx-proxy container for reverse proxy creations,
 #   for docs refer to https://github.com/nginx-proxy/nginx-proxy.

--- a/.github/updatecli.yaml
+++ b/.github/updatecli.yaml
@@ -13,7 +13,7 @@ sources:
   elasticsearch:
     kind: dockerimage
     spec:
-      image: "bitnami/elasticsearch"
+      image: "elasticsearch"
       architecture: "linux/amd64"
       versionfilter:
         kind: "semver"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     environment:
       discovery.type: single-node
       xpack.security.enabled: 'false'
-      ES_JAVA_OPTS: '-Xms1g -Xmx1g'
+      ES_JAVA_OPTS: ${ELASTICSEARCH_JAVA_OPTS:--Xms1g -Xmx1g}
 
   zammad-init:
     <<: *zammad-service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ x-shared:
       ELASTICSEARCH_SCHEMA:
       ELASTICSEARCH_HOST:
       ELASTICSEARCH_PORT:
-      ELASTICSEARCH_USER: ${ELASTICSEARCH_USER:-elastic}
-      ELASTICSEARCH_PASS: ${ELASTICSEARCH_PASS:-zammad}
+      ELASTICSEARCH_USER:
+      ELASTICSEARCH_PASS:
       ELASTICSEARCH_NAMESPACE:
       ELASTICSEARCH_REINDEX:
       NGINX_PORT:
@@ -71,26 +71,14 @@ services:
     user: 0:0
 
   zammad-elasticsearch:
-    image: bitnami/elasticsearch:${ELASTICSEARCH_VERSION:-8.18.0}
+    image: elasticsearch:${ELASTICSEARCH_VERSION:-8.18.0}
     restart: ${RESTART:-always}
     volumes:
-      - elasticsearch-data:/bitnami/elasticsearch/data
+      - elasticsearch-data:/usr/share/elasticsearch/data
     environment:
-      # See https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch#environment-variables
-      #
-      # Enable authorization without HTTPS. For external access with
-      #   SSL termination, use solutions like nginx-proxy-manager.
-      ELASTICSEARCH_ENABLE_SECURITY: 'true'
-      ELASTICSEARCH_SKIP_TRANSPORT_TLS: 'true'
-      ELASTICSEARCH_ENABLE_REST_TLS: 'false'
-      # ELASTICSEARCH_USER is hardcoded to 'elastic' in the container.
-      ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_PASS:-zammad}
-      # Resource settings
-      ELASTICSEARCH_HEAP_SIZE:
-      ELASTICSEARCH_MAX_ALLOWED_MEMORY_PERCENTAGE:
-      ELASTICSEARCH_MAX_ALLOWED_MEMORY:
-      ELASTICSEARCH_MAX_TIMEOUT:
-      ELASTICSEARCH_LOCK_ALL_MEMORY:
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+      ES_JAVA_OPTS: '-Xms1g -Xmx1g'
 
   zammad-init:
     <<: *zammad-service


### PR DESCRIPTION
- Fixes: #498 

### Breaking Changes

Requires a manual update step to fix file permissions in the `elasticsearch-data` volume:

```
docker compose run -it -u0 zammad-elasticsearch chown elasticsearch -Rv /usr/share/elasticsearch/data
changed ownership of '/usr/share/elasticsearch/data/node.lock' from 1001 to elasticsearch
changed ownership of '/usr/share/elasticsearch/data/nodes' from 1001 to elasticsearch
…
```
