### PR TITLE
Removing deprecated Docker Version String from compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment


### PR DESCRIPTION
## PR Description

This PR removes the explicit version string (`version: "3"`) from the `docker-compose.yml`.

## Rationale

- **Deprecated in Compose Specification**  
  The Docker Compose specification no longer requires or recommends using the `version` field. Starting with Compose v1.27.0 and the introduction of the [Compose Specification](https://docs.docker.com/compose/compose-file/compose-versioning/), the `version` key has been deprecated.

- **Improved Forward Compatibility**  
  By removing the version declaration, the file is parsed against the latest Compose specification by default. This ensures that new features and improvements introduced in Compose will be available without needing to bump the version manually.

- **Reduces Maintenance Overhead**  
  Explicit version numbers can cause unnecessary churn and confusion, especially when developers assume they must be updated with new Docker releases. Omitting the field simplifies the file and avoids misleading future contributors.

- **Broad Compatibility**  
  Modern Docker and Docker Compose versions handle files without `version:` seamlessly. Keeping it in place only creates the impression that specific constraints exist, which is no longer the case.

## References

- [Docker Docs: Compose file version and upgrading](https://docs.docker.com/compose/compose-file/compose-versioning/)  
- [Compose Specification](https://compose-spec.io/)

## Summary

This change aligns the Zammad `docker-compose.yml` with current Docker best practices, reduces confusion, and improves maintainability going forward.
