### PR TITLE
Upgrade PostgreSQL to v18.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-zammad_production}
       POSTGRES_USER: ${POSTGRES_USER:-zammad}
       POSTGRES_PASSWORD: ${POSTGRES_PASS:-zammad}
-    image: postgres:${POSTGRES_VERSION:-17.7-alpine}
+    image: postgres:${POSTGRES_VERSION:-18.1-alpine}
     restart: ${RESTART:-always}
     volumes:
       - postgresql-data:/var/lib/postgresql/data


### PR DESCRIPTION
When I'm getting-started, I like to run directly the latest PostgreSQL image.