### PR TITLE
Drop obsolete version attribute from compose.yml files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment

--- a/scenarios/add-cloudflare-tunnel.yml
+++ b/scenarios/add-cloudflare-tunnel.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Expose Zammad via cloudflare.
 #

--- a/scenarios/add-external-network-to-elasticsearch.yml
+++ b/scenarios/add-external-network-to-elasticsearch.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Adds an external network to Zammad's elasticsearch container, for example to
 #   use it with an existing reverse proxy like nginx proxy manager.

--- a/scenarios/add-external-network-to-nginx.yml
+++ b/scenarios/add-external-network-to-nginx.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Adds an external network to Zammad's nginx container, for example to
 #   use it with an existing reverse proxy like nginx proxy manager.

--- a/scenarios/add-hostport-to-elasticsearch.yml
+++ b/scenarios/add-hostport-to-elasticsearch.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Exposes Zammad's elasticsearch container on the host, for example to
 #   connect to it from another host.

--- a/scenarios/add-nginx-proxy-manager.yml
+++ b/scenarios/add-nginx-proxy-manager.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Adds an nginx-proxy-manager service to the stack, for example to
 #   expose Zammad publicly via HTTPS.

--- a/scenarios/add-ollama.yml
+++ b/scenarios/add-ollama.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Adds an ollama service to the stack, for example for local AI tests.
 #

--- a/scenarios/apply-resource-limits.yml
+++ b/scenarios/apply-resource-limits.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Apply resource limits to the Zammad services.
 #

--- a/scenarios/disable-backup-service.yml
+++ b/scenarios/disable-backup-service.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Disable the built-in zammad-backup service, for example if backup is handled differently.
 #

--- a/scenarios/disable-elasticsearch-service.yml
+++ b/scenarios/disable-elasticsearch-service.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 #
 # Disable the built-in zammad-elasticsearch service, for example if
 #   an external elasticsearch is used.


### PR DESCRIPTION
```plain
docker compose up
WARN[0000] zammad-docker-compose/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
…
```