### PR TITLE
fix #554 - add nested .env vars for PostgreSQL

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,7 +7,7 @@
 # docker-compose.yml - These variables only need to be set if they do not have the default value.
 #############################################
 
-# RESTART=always
+RESTART=always
 
 # Use a fixed Zammad version rather than the default. If you do so,
 #   you are responsible to update this to newer patch level versions yourself.
@@ -34,14 +34,13 @@
 # NGINX_EXPOSE_PORT=8080
 # NGINX_CLIENT_MAX_BODY_SIZE=50M
 
-# POSTGRESQL_DB=zammad_production
-# POSTGRESQL_HOST=zammad-postgresql
-# POSTGRESQL_USER=zammad
-# POSTGRESQL_PASS=zammad
-# POSTGRESQL_PORT=5432
-# POSTGRESQL_OPTIONS=?pool=50
+# POSTGRESQL_DB=
+# POSTGRESQL_HOST=
+# POSTGRESQL_USER=
+# POSTGRESQL_PASS=
+# POSTGRESQL_PORT=
+# POSTGRESQL_OPTIONS=
 # POSTGRESQL_DB_CREATE=
-
 
 # ELASTICSEARCH_SCHEMA=http
 # ELASTICSEARCH_HOST=zammad-elasticsearch

--- a/.env.dist
+++ b/.env.dist
@@ -1,6 +1,6 @@
 #############################################
 # Docker Environment Variables
-# https://docs.zammad.org/en/latest/install/docker-compose/environment.html
+# https://docs.zammad.org/en/latest/appendix/environment-variables.html
 #############################################
 
 #############################################
@@ -33,12 +33,15 @@
 # NGINX_PORT=8080
 # NGINX_EXPOSE_PORT=8080
 # NGINX_CLIENT_MAX_BODY_SIZE=50M
-# POSTGRES_DB=zammad_production
-# POSTGRES_PASS=zammad
-# POSTGRES_USER=zammad
-# POSTGRES_HOST=zammad-postgresql
-# POSTGRES_PORT=5432
+
+# POSTGRESQL_DB=zammad_production
+# POSTGRESQL_HOST=zammad-postgresql
+# POSTGRESQL_USER=zammad
+# POSTGRESQL_PASS=zammad
+# POSTGRESQL_PORT=5432
 # POSTGRESQL_OPTIONS=?pool=50
+# POSTGRESQL_DB_CREATE=
+
 
 # ELASTICSEARCH_SCHEMA=http
 # ELASTICSEARCH_HOST=zammad-elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,14 @@ x-shared:
   zammad-service: &zammad-service
     environment: &zammad-environment
       MEMCACHE_SERVERS: ${MEMCACHE_SERVERS:-zammad-memcached:11211}
-      POSTGRESQL_DB: ${POSTGRES_DB:-zammad_production}
-      POSTGRESQL_HOST: ${POSTGRES_HOST:-zammad-postgresql}
-      POSTGRESQL_USER: ${POSTGRES_USER:-zammad}
-      POSTGRESQL_PASS: ${POSTGRES_PASS:-zammad}
-      POSTGRESQL_PORT: ${POSTGRES_PORT:-5432}
-      POSTGRESQL_OPTIONS: ${POSTGRESQL_OPTIONS:-?pool=50}
+      
+      # PostgreSQL
+      POSTGRESQL_DB: ${POSTGRESQL_DB:-${POSTGRES_DB:-zammad_production}}
+      POSTGRESQL_HOST: ${POSTGRESQL_HOST:-${POSTGRES_HOST:-zammad-postgresql}}
+      POSTGRESQL_USER: ${POSTGRESQL_USER:-${POSTGRES_USER:-zammad}}
+      POSTGRESQL_PASS: ${POSTGRESQL_PASS:-${POSTGRES_PASS:-${POSTGRES_PASSWORD:-zammad}}}
+      POSTGRESQL_PORT: ${POSTGRESQL_PORT:-${POSTGRES_PORT:-5432}}
+      POSTGRESQL_OPTIONS: ${POSTGRESQL_OPTIONS:-${POSTGRES_OPTIONS:-?pool=50}}
       POSTGRESQL_DB_CREATE:
 
       # Redis standalone
@@ -123,9 +125,9 @@ services:
 
   zammad-postgresql:
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-zammad_production}
-      POSTGRES_USER: ${POSTGRES_USER:-zammad}
-      POSTGRES_PASSWORD: ${POSTGRES_PASS:-zammad}
+      POSTGRES_DB: ${POSTGRESQL_DB:-${POSTGRES_DB:-zammad_production}}
+      POSTGRES_USER: ${POSTGRESQL_USER:-${POSTGRES_USER:-zammad}}
+      POSTGRES_PASSWORD: ${POSTGRESQL_PASS:-${POSTGRES_PASS:-${POSTGRES_PASSWORD:-zammad}}}
     image: postgres:${POSTGRES_VERSION:-17.9-alpine}
     restart: ${RESTART:-always}
     volumes:


### PR DESCRIPTION
    - Renamed `POSTGRES_*` to `POSTGRESQL_*` in environment variables for the Zammad service
    - Implemented nested `.env` variables to support both old and new variable names:
